### PR TITLE
always create a model if not present

### DIFF
--- a/lib/worker_tools/basics.rb
+++ b/lib/worker_tools/basics.rb
@@ -72,10 +72,6 @@ module WorkerTools
       %w[error warning]
     end
 
-    def create_model_if_not_available
-      false
-    end
-
     def model
       @model ||= find_model
     end
@@ -93,7 +89,6 @@ module WorkerTools
       @model_id ||= nil
       return @model_id if @model_id.is_a?(model_class)
       return model_class.find(@model_id) if @model_id
-      raise 'Model not available' unless create_model_if_not_available
 
       t = model_class.new
       t.kind = model_kind if t.respond_to?(:kind=)

--- a/test/worker_tools/basics_test.rb
+++ b/test/worker_tools/basics_test.rb
@@ -78,13 +78,8 @@ describe WorkerTools::Basics do
       assert_equal import, importer.model
     end
 
-    it 'creates the model if create_model_if_not_available is set' do
+    it 'creates the model if not present' do
       importer = Importer.new
-      err = assert_raises(StandardError) { importer.model }
-      assert_includes err.message, 'Model not available'
-
-      importer = Importer.new
-      importer.expects(:create_model_if_not_available).returns(true)
       import = importer.model
       assert_instance_of Import, import
     end

--- a/test/worker_tools/benchmark_test.rb
+++ b/test/worker_tools/benchmark_test.rb
@@ -33,10 +33,5 @@ describe WorkerTools::CustomBenchmark do
       @importer.perform(@import)
       expect(@importer.model.meta['duration']).must_equal 2
     end
-
-    it 'raise error if model.meta not exist' do
-      err = assert_raises(StandardError) { @importer.with_wrapper_benchmark }
-      assert_includes err.message, 'Model not available'
-    end
   end
 end

--- a/test/worker_tools/counters_test.rb
+++ b/test/worker_tools/counters_test.rb
@@ -92,11 +92,6 @@ describe WorkerTools::Counters do
       @importer.expects(:reset_counters).returns(true)
       @importer.perform(@import)
     end
-
-    it 'raise error if model.meta not exist' do
-      err = assert_raises(StandardError) { @importer.with_wrapper_counters }
-      assert_includes err.message, 'Model not available'
-    end
   end
 
   describe 'reset_counters' do


### PR DESCRIPTION
BREAKING CHANGE: `create_model_if_not_available` has been removed.