### PR TITLE
Simplify output methods related to file persistance, unify csv & xlsx output content methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ end
 ```
 
 ## Complete Examples
+### XLSX Input Example
 
 ```ruby
 # Example with XlsxInput

--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ class CsvInputExample
   end
 end
 ```
+### CSV Output Example
 
 ```ruby
 # More complex example with CsvOutput

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The modules that generate a file expect the model to provide an `add_attachment`
   end
 ```
 
-You can skip this convention overwriting the module related method, for example after including `CsvOutput`
+You can skip this convention by overwriting the module related method, for example after including `CsvOutput`
 
 ```ruby
 def csv_output_add_attachment

--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ class CsvOutputExample
 
 end
 ```
+### XLSX Output Example
 
 ```ruby
 # ExampleXlsxOutput

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@
     <li><a href="#wrappers">Wrappers</a></li>
     <li><a href="#module-notes">Module 'Notes'</a></li>
     <li><a href="#attachments">Attachments</a></li>
-    <li><a href="#complete-examples">Complete Examples</a></li>
+    <li>
+      <a href="#complete-examples">Complete Examples</a>
+      <ul>
+        <li><a href="#xlsx-input-example">XLSX Input Example</a></li>
+        <li><a href="#csv-input-example">CSV Input Example</a></li>
+        <li><a href="#csv-output-example">CSV Output Example</a></li>
+        <li><a href="#xlsx-output-example">XLSX Output Example</a></li>
+      </ul>
+    </li>
     <li><a href="#requirements">Requirements</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ class XlsxInputExample
   end
 end
 ```
+### CSV Input Example
 
 ```ruby
 # Example with CsvInput

--- a/lib/worker_tools/csv_output.rb
+++ b/lib/worker_tools/csv_output.rb
@@ -38,18 +38,6 @@ module WorkerTools
     end
     # rubocop:enable Lint/UnusedMethodArgument
 
-    def cvs_output_target_folder
-      File.dirname(csv_output_target)
-    end
-
-    def csv_output_target_file_name
-      File.basename(csv_output_target)
-    end
-
-    def csv_ouput_ensure_target_folder
-      FileUtils.mkdir_p(cvs_output_target_folder) unless File.directory?(cvs_output_target_folder)
-    end
-
     def csv_output_tmp_file
       @csv_output_tmp_file ||= Tempfile.new(['output', '.csv'])
     end
@@ -74,17 +62,17 @@ module WorkerTools
       csv << csv_output_column_headers.values if csv_output_column_headers
     end
 
+    def csv_output_add_attachment
+      model.add_attachment(csv_output_tmp_file, file_name: model_file_name, content_type: 'text/csv')
+    end
+
     def csv_output_write_file
       CSV.open(csv_output_tmp_file, csv_output_write_mode, **csv_output_csv_options) do |csv|
         csv_output_insert_headers(csv)
         csv_output_entries.each { |entry| csv << csv_output_row_values(entry) }
       end
-      csv_output_write_target if csv_output_target
-    end
 
-    def csv_output_write_target
-      csv_ouput_ensure_target_folder
-      FileUtils.cp(csv_output_tmp_file.path, csv_output_target)
+      csv_output_add_attachment
     end
   end
 end

--- a/lib/worker_tools/csv_output.rb
+++ b/lib/worker_tools/csv_output.rb
@@ -2,13 +2,6 @@ require 'csv'
 
 module WorkerTools
   module CsvOutput
-    # if defined, this file will be written to this destination (regardless
-    # of whether the model saves the file as well)
-    def csv_output_target
-      # Ex: Rails.root.join('shared', 'foo', 'bar.csv')
-      false
-    end
-
     def csv_output_entries
       raise "csv_output_entries has to be defined in #{self}"
     end
@@ -42,6 +35,10 @@ module WorkerTools
       @csv_output_tmp_file ||= Tempfile.new(['output', '.csv'])
     end
 
+    def csv_output_file_name
+      "#{model_kind}.csv"
+    end
+
     def csv_output_col_sep
       ';'
     end
@@ -63,7 +60,7 @@ module WorkerTools
     end
 
     def csv_output_add_attachment
-      model.add_attachment(csv_output_tmp_file, file_name: model_file_name, content_type: 'text/csv')
+      model.add_attachment(csv_output_tmp_file, file_name: csv_output_file_name, content_type: 'text/csv')
     end
 
     def csv_output_write_file

--- a/lib/worker_tools/csv_output.rb
+++ b/lib/worker_tools/csv_output.rb
@@ -20,16 +20,9 @@ module WorkerTools
       raise "csv_output_column_headers has to be defined in #{self}"
     end
 
-    # rubocop:disable Lint/UnusedMethodArgument
     def csv_output_row_values(entry)
-      # Ex:
-      # {
-      #   foo: entry.foo,
-      #   bar: entry.bar
-      # }.values_at(*csv_output_column_headers.keys)
-      raise "csv_output_row_values has to be defined in #{self}"
+      entry.values_at(*csv_output_column_headers.keys)
     end
-    # rubocop:enable Lint/UnusedMethodArgument
 
     def csv_output_tmp_file
       @csv_output_tmp_file ||= Tempfile.new(['output', '.csv'])

--- a/lib/worker_tools/xlsx_output.rb
+++ b/lib/worker_tools/xlsx_output.rb
@@ -59,7 +59,7 @@ module WorkerTools
       FileUtils.mkdir_p(xlsx_output_target_folder) unless File.directory?(xlsx_output_target_folder)
     end
 
-    def xlsx_insert_headers(spreadsheet, headers)
+    def xlsx_output_insert_headers(spreadsheet, headers)
       return unless headers
 
       iterator =
@@ -73,15 +73,15 @@ module WorkerTools
       end
     end
 
-    def xlsx_insert_rows(spreadsheet, rows, headers)
+    def xlsx_output_insert_rows(spreadsheet, rows, headers)
       rows.each_with_index do |row, row_index|
-        xlsx_iterators(row, headers).each_with_index do |value, col_index|
+        xlsx_output_iterators(row, headers).each_with_index do |value, col_index|
           spreadsheet.add_cell(row_index + 1, col_index, value.to_s)
         end
       end
     end
 
-    def xlsx_iterators(iterable, compare_hash = nil)
+    def xlsx_output_iterators(iterable, compare_hash = nil)
       if iterable.is_a? Hash
         raise 'parameter compare_hash should be a hash, too.' if compare_hash.nil? || !compare_hash.is_a?(Hash)
 
@@ -91,10 +91,10 @@ module WorkerTools
       end
     end
 
-    def xlsx_style_columns(spreadsheet, styles, headers)
+    def xlsx_output_style_columns(spreadsheet, styles, headers)
       return false unless headers
 
-      xlsx_iterators(styles, headers).each_with_index do |format, index|
+      xlsx_output_iterators(styles, headers).each_with_index do |format, index|
         next unless format
 
         spreadsheet.change_column_width(index, format[:width])
@@ -103,22 +103,22 @@ module WorkerTools
       true
     end
 
-    def xlsx_write_sheet(workbook, sheet_content, index)
+    def xlsx_output_write_sheet(workbook, sheet_content, index)
       sheet = workbook.worksheets[index]
       sheet = workbook.add_worksheet(sheet_content[:label]) if sheet.nil?
 
       sheet.sheet_name = sheet_content[:label]
-      xlsx_style_columns(sheet, sheet_content[:column_style], sheet_content[:headers])
-      xlsx_insert_headers(sheet, sheet_content[:headers])
-      xlsx_insert_rows(sheet, sheet_content[:rows], sheet_content[:headers])
+      xlsx_output_style_columns(sheet, sheet_content[:column_style], sheet_content[:headers])
+      xlsx_output_insert_headers(sheet, sheet_content[:headers])
+      xlsx_output_insert_rows(sheet, sheet_content[:rows], sheet_content[:headers])
     end
 
-    def xlsx_write_output_target
+    def xlsx_output_write_output_target
       xlsx_ensure_output_target_folder
 
       book = RubyXL::Workbook.new
       xlsx_output_content.each_with_index do |(_, object), index|
-        xlsx_write_sheet(book, object, index)
+        xlsx_output_write_sheet(book, object, index)
       end
 
       book.write xlsx_output_target

--- a/lib/worker_tools/xlsx_output.rb
+++ b/lib/worker_tools/xlsx_output.rb
@@ -13,14 +13,14 @@ module WorkerTools
         sheet1: {
           label: 'Sheet 1',
           headers: xlsx_output_column_headers,
-          rows: xlsx_output_values,
+          rows: xlsx_output_row_values,
           column_style: xlsx_output_column_format
         }
       }
     end
 
-    def xlsx_output_values
-      raise "xlsx_output_values has to be defined in #{self}"
+    def xlsx_output_row_values
+      raise "xlsx_output_row_values has to be defined in #{self}"
     end
 
     def xlsx_output_column_headers

--- a/lib/worker_tools/xlsx_output.rb
+++ b/lib/worker_tools/xlsx_output.rb
@@ -1,19 +1,8 @@
 require 'rubyXL'
 module WorkerTools
   module XlsxOutput
-    def xlsx_output_content
-      {
-        sheet1: {
-          label: 'Sheet 1',
-          headers: xlsx_output_column_headers,
-          rows: xlsx_output_row_values,
-          column_style: xlsx_output_column_format
-        }
-      }
-    end
-
-    def xlsx_output_row_values
-      raise "xlsx_output_row_values has to be defined in #{self}"
+    def xlsx_output_entries
+      raise "xlsx_output_entries has to be defined in #{self}"
     end
 
     def xlsx_output_column_headers
@@ -28,6 +17,21 @@ module WorkerTools
       #   bar: 'Bar Header'
       # }
       raise "xlsx_output_column_headers has to be defined in #{self}"
+    end
+
+    def xlsx_output_content
+      {
+        sheet1: {
+          label: 'Sheet 1',
+          headers: xlsx_output_column_headers,
+          rows: xlsx_output_entries.lazy.map { |entry| xlsx_output_row_values(entry) },
+          column_style: xlsx_output_column_format
+        }
+      }
+    end
+
+    def xlsx_output_row_values(entry)
+      entry.values_at(*xlsx_output_column_headers.keys)
     end
 
     def xlsx_output_column_format

--- a/lib/worker_tools/xlsx_output.rb
+++ b/lib/worker_tools/xlsx_output.rb
@@ -1,13 +1,6 @@
 require 'rubyXL'
 module WorkerTools
   module XlsxOutput
-    # if defined, this file will be written to this destination (regardless
-    # of whether the model saves the file as well)
-    def xlsx_output_target
-      # Ex: Rails.root.join('shared', 'foo', 'bar.xlsx')
-      raise "xlsx_output_target has to be defined in #{self}"
-    end
-
     def xlsx_output_content
       {
         sheet1: {
@@ -99,10 +92,14 @@ module WorkerTools
       @xlsx_output_tmp_file ||= Tempfile.new(['output', '.xlsx'])
     end
 
+    def xlsx_output_file_name
+      "#{model_kind}.xlsx"
+    end
+
     def xlsx_output_add_attachment
       model.add_attachment(
         xlsx_output_tmp_file,
-        file_name: model_file_name,
+        file_name: xlsx_output_file_name,
         content_type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
       )
     end

--- a/test/models.rb
+++ b/test/models.rb
@@ -1,3 +1,13 @@
 class Import < ActiveRecord::Base
   enum state: { waiting: 0, complete: 1, failed: 2, complete_with_warnings: 3 }
+
+  attr_accessor :attachments
+
+  after_initialize { self.attachments = [] }
+
+  def add_attachment(file, file_name: nil, content_type: nil)
+    attachments << Attachment.new(file, file_name, content_type)
+  end
 end
+
+Attachment = Struct.new(:file, :file_name, :content_type)

--- a/test/worker_tools/csv_output_test.rb
+++ b/test/worker_tools/csv_output_test.rb
@@ -32,12 +32,6 @@ describe WorkerTools::CsvOutput do
     assert_includes err.message, 'csv_output_entries has to be defined in'
   end
 
-  it 'needs csv_output_row_values(arg) to be defined' do
-    klass = FooCsvOutput.new
-    err = assert_raises(RuntimeError) { klass.csv_output_row_values(1) }
-    assert_includes err.message, 'csv_output_row_values has to be defined in'
-  end
-
   describe 'csv file output' do
     class FooCorrect < FooCsvOutput
       def csv_output_column_headers
@@ -60,10 +54,6 @@ describe WorkerTools::CsvOutput do
             col_3: 'cell_2.3'
           }
         ]
-      end
-
-      def csv_output_row_values(entry)
-        entry.values_at(*csv_output_column_headers.keys)
       end
     end
 

--- a/test/worker_tools/csv_output_test.rb
+++ b/test/worker_tools/csv_output_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe WorkerTools::CsvOutput do
-  class Foo
+  class FooCsvOutput
     include WorkerTools::Basics
     include WorkerTools::CsvOutput
 
@@ -21,25 +21,25 @@ describe WorkerTools::CsvOutput do
   end
 
   it 'needs csv_output_column_headers to be defined' do
-    klass = Foo.new
+    klass = FooCsvOutput.new
     err = assert_raises(RuntimeError) { klass.csv_output_column_headers }
     assert_includes err.message, 'csv_output_column_headers has to be defined in'
   end
 
   it 'needs csv_output_entries to be defined' do
-    klass = Foo.new
+    klass = FooCsvOutput.new
     err = assert_raises(RuntimeError) { klass.csv_output_entries }
     assert_includes err.message, 'csv_output_entries has to be defined in'
   end
 
   it 'needs csv_output_row_values(arg) to be defined' do
-    klass = Foo.new
+    klass = FooCsvOutput.new
     err = assert_raises(RuntimeError) { klass.csv_output_row_values(1) }
     assert_includes err.message, 'csv_output_row_values has to be defined in'
   end
 
   describe 'csv file output' do
-    class FooCorrect < Foo
+    class FooCorrect < FooCsvOutput
       def csv_output_column_headers
         {
           col_1: 'Col 1',
@@ -122,7 +122,7 @@ describe WorkerTools::CsvOutput do
 
   describe '#csv_output_write_mode' do
     it 'sets the csv write mode' do
-      klass = Foo.new
+      klass = FooCsvOutput.new
       klass.expects(:csv_output_write_mode).returns('write mode')
       CSV.expects(:open).with(anything, 'write mode', anything)
 
@@ -132,7 +132,7 @@ describe WorkerTools::CsvOutput do
 
   describe '#csv_output_csv_options' do
     it 'sets col_sep and encoding' do
-      klass = Foo.new
+      klass = FooCsvOutput.new
       klass.expects(:csv_output_col_sep).returns('col sep')
       klass.expects(:csv_output_encoding).returns('encoding')
       CSV.expects(:open).with(anything, anything, col_sep: 'col sep', encoding: 'encoding')
@@ -141,7 +141,7 @@ describe WorkerTools::CsvOutput do
     end
 
     it 'sets the csv open options' do
-      klass = Foo.new
+      klass = FooCsvOutput.new
       klass.expects(:csv_output_csv_options).returns(some: :options)
       CSV.expects(:open).with(anything, anything, some: :options)
 

--- a/test/worker_tools/csv_output_test.rb
+++ b/test/worker_tools/csv_output_test.rb
@@ -96,16 +96,11 @@ describe WorkerTools::CsvOutput do
     end
 
     it 'successful writing of csv file with custom file name' do
+      @klass.expects(:csv_output_file_name).returns('custom.csv')
       @klass.csv_output_write_file
       attachment = @klass.model.attachments.first
       assert attachment
-      assert_equal "Col 1;Col 2\ncell_1.1ä;cell_1.2ü\ncell_2.1;cell_2.2\n", attachment.file.read
-    end
-
-    it 'successful writing of csv file with custom file name within given folder' do
-      @klass.csv_output_write_file
-      attachment = @klass.model.attachments.first
-      assert attachment
+      assert_equal(attachment.file_name, 'custom.csv')
       assert_equal "Col 1;Col 2\ncell_1.1ä;cell_1.2ü\ncell_2.1;cell_2.2\n", attachment.file.read
     end
   end

--- a/test/worker_tools/xlsx_output_test.rb
+++ b/test/worker_tools/xlsx_output_test.rb
@@ -62,9 +62,9 @@ describe WorkerTools::XlsxOutput do
 
     it 'successful writing of xlsx file' do
       assert @klass.xlsx_output_column_format
-      @klass.expects(:xlsx_style_columns).returns(true)
+      @klass.expects(:xlsx_output_style_columns).returns(true)
 
-      @klass.xlsx_write_output_target
+      @klass.xlsx_output_write_output_target
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 
@@ -116,9 +116,9 @@ describe WorkerTools::XlsxOutput do
 
     it 'successful writing of xlsx file' do
       assert @klass.xlsx_output_column_format
-      @klass.expects(:xlsx_style_columns).returns(true)
+      @klass.expects(:xlsx_output_style_columns).returns(true)
 
-      @klass.xlsx_write_output_target
+      @klass.xlsx_output_write_output_target
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 
@@ -180,9 +180,9 @@ describe WorkerTools::XlsxOutput do
 
     it 'successful writing of xlsx file' do
       assert @klass.xlsx_output_column_format
-      @klass.expects(:xlsx_style_columns).at_least_once
+      @klass.expects(:xlsx_output_style_columns).at_least_once
 
-      @klass.xlsx_write_output_target
+      @klass.xlsx_output_write_output_target
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 
@@ -248,9 +248,9 @@ describe WorkerTools::XlsxOutput do
 
     it 'successful writing of xlsx file' do
       assert @klass.xlsx_output_column_format
-      @klass.expects(:xlsx_style_columns).at_least_once
+      @klass.expects(:xlsx_output_style_columns).at_least_once
 
-      @klass.xlsx_write_output_target
+      @klass.xlsx_output_write_output_target
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 

--- a/test/worker_tools/xlsx_output_test.rb
+++ b/test/worker_tools/xlsx_output_test.rb
@@ -12,14 +12,12 @@ describe WorkerTools::XlsxOutput do
     end
 
     def model_kind
-      'foo/test'
+      'foo_test'
     end
-  end
 
-  it 'needs xlsx_output_target to be defined' do
-    klass = Foo.new
-    err = assert_raises(RuntimeError) { klass.xlsx_output_target }
-    assert_includes err.message, 'xlsx_output_target has to be defined in'
+    def create_model_if_not_available
+      true
+    end
   end
 
   it 'needs xlsx_output_row_values to be defined' do
@@ -47,10 +45,6 @@ describe WorkerTools::XlsxOutput do
         ]
       end
 
-      def xlsx_output_target
-        './tmp/foo_correct.xlsx'
-      end
-
       def xlsx_output_column_format
         {
           a: { width: 20.0, text_wrap: true },
@@ -64,7 +58,6 @@ describe WorkerTools::XlsxOutput do
     end
 
     it 'no method definition raises and methods are well defined' do
-      assert @klass.xlsx_output_target
       assert @klass.xlsx_output_row_values
       assert @klass.xlsx_output_column_headers
     end
@@ -74,8 +67,9 @@ describe WorkerTools::XlsxOutput do
       @klass.expects(:xlsx_output_style_columns).returns(true)
 
       @klass.xlsx_output_write_file
-      assert File.exist?(@klass.xlsx_output_target)
-      xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
+      attachment = @klass.model.attachments.first
+      assert attachment
+      xlsx = Roo::Excelx.new(attachment.file.path)
 
       sheet = xlsx.sheet(0)
       assert sheet
@@ -106,10 +100,6 @@ describe WorkerTools::XlsxOutput do
           b: { width: 10.0, text_wrap: true }
         }
       end
-
-      def xlsx_output_target
-        './tmp/foo_correct.xlsx'
-      end
     end
 
     def setup
@@ -117,7 +107,6 @@ describe WorkerTools::XlsxOutput do
     end
 
     it 'no method definition raises and methods are well defined' do
-      assert @klass.xlsx_output_target
       assert @klass.xlsx_output_row_values
       assert @klass.xlsx_output_column_headers
     end
@@ -127,8 +116,9 @@ describe WorkerTools::XlsxOutput do
       @klass.expects(:xlsx_output_style_columns).returns(true)
 
       @klass.xlsx_output_write_file
-      assert File.exist?(@klass.xlsx_output_target)
-      xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
+      attachment = @klass.model.attachments.first
+      assert attachment
+      xlsx = Roo::Excelx.new(attachment.file.path)
 
       sheet = xlsx.sheet(0)
       assert sheet
@@ -140,10 +130,6 @@ describe WorkerTools::XlsxOutput do
 
   describe 'xlsx file output with array - multi sheet' do
     class FooCorrectArrayMultiSheet < Foo
-      def xlsx_output_target
-        './tmp/foo_correct.xlsx'
-      end
-
       def xlsx_output_content
         {
           sheet_1: {
@@ -189,8 +175,12 @@ describe WorkerTools::XlsxOutput do
       @klass.expects(:xlsx_output_style_columns).at_least_once
 
       @klass.xlsx_output_write_file
-      assert File.exist?(@klass.xlsx_output_target)
-      xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
+      attachment = @klass.model.attachments.first
+      assert attachment
+      assert_instance_of Tempfile, attachment.file
+      assert_equal 'foo_test.xlsx', attachment.file_name
+      assert_equal 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', attachment.content_type
+      xlsx = Roo::Excelx.new(attachment.file.path)
 
       assert xlsx.sheet(0)
       assert xlsx.sheet(1)
@@ -224,10 +214,6 @@ describe WorkerTools::XlsxOutput do
         }
       end
 
-      def xlsx_output_target
-        './tmp/foo_correct.xlsx'
-      end
-
       def xlsx_output_content
         {
           sheet_1: {
@@ -255,8 +241,9 @@ describe WorkerTools::XlsxOutput do
       @klass.expects(:xlsx_output_style_columns).at_least_once
 
       @klass.xlsx_output_write_file
-      assert File.exist?(@klass.xlsx_output_target)
-      xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
+      attachment = @klass.model.attachments.first
+      assert attachment
+      xlsx = Roo::Excelx.new(attachment.file.path)
 
       assert xlsx.sheet(0)
       assert xlsx.sheet(1)

--- a/test/worker_tools/xlsx_output_test.rb
+++ b/test/worker_tools/xlsx_output_test.rb
@@ -2,7 +2,18 @@ require 'test_helper'
 
 describe WorkerTools::XlsxOutput do
   class Foo
+    include WorkerTools::Basics
     include WorkerTools::XlsxOutput
+
+    wrappers :basics
+
+    def model_class
+      Import
+    end
+
+    def model_kind
+      'foo/test'
+    end
   end
 
   it 'needs xlsx_output_target to be defined' do
@@ -24,9 +35,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with array' do
-    class FooCorrectArray
-      include WorkerTools::XlsxOutput
-
+    class FooCorrectArray < Foo
       def xlsx_output_column_headers
         %w[foo1 goo2]
       end
@@ -64,7 +73,7 @@ describe WorkerTools::XlsxOutput do
       assert @klass.xlsx_output_column_format
       @klass.expects(:xlsx_output_style_columns).returns(true)
 
-      @klass.xlsx_output_write_output_target
+      @klass.xlsx_output_write_file
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 
@@ -78,8 +87,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with hash' do
-    class FooCorrectHash
-      include WorkerTools::XlsxOutput
+    class FooCorrectHash < Foo
 
       def xlsx_output_column_headers
         { a: 'foo1', b: 'goo2' }
@@ -118,7 +126,7 @@ describe WorkerTools::XlsxOutput do
       assert @klass.xlsx_output_column_format
       @klass.expects(:xlsx_output_style_columns).returns(true)
 
-      @klass.xlsx_output_write_output_target
+      @klass.xlsx_output_write_file
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 
@@ -131,9 +139,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with array - multi sheet' do
-    class FooCorrectArrayMultiSheet
-      include WorkerTools::XlsxOutput
-
+    class FooCorrectArrayMultiSheet < Foo
       def xlsx_output_target
         './tmp/foo_correct.xlsx'
       end
@@ -182,7 +188,7 @@ describe WorkerTools::XlsxOutput do
       assert @klass.xlsx_output_column_format
       @klass.expects(:xlsx_output_style_columns).at_least_once
 
-      @klass.xlsx_output_write_output_target
+      @klass.xlsx_output_write_file
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 
@@ -199,9 +205,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with hash - multi sheet' do
-    class FooCorrectHashMultiSheet
-      include WorkerTools::XlsxOutput
-
+    class FooCorrectHashMultiSheet < Foo
       def xlsx_output_column_headers
         { a: 'foo1', b: 'goo2' }
       end
@@ -250,7 +254,7 @@ describe WorkerTools::XlsxOutput do
       assert @klass.xlsx_output_column_format
       @klass.expects(:xlsx_output_style_columns).at_least_once
 
-      @klass.xlsx_output_write_output_target
+      @klass.xlsx_output_write_file
       assert File.exist?(@klass.xlsx_output_target)
       xlsx = Roo::Excelx.new('./tmp/foo_correct.xlsx')
 

--- a/test/worker_tools/xlsx_output_test.rb
+++ b/test/worker_tools/xlsx_output_test.rb
@@ -11,10 +11,10 @@ describe WorkerTools::XlsxOutput do
     assert_includes err.message, 'xlsx_output_target has to be defined in'
   end
 
-  it 'needs xlsx_output_values to be defined' do
+  it 'needs xlsx_output_row_values to be defined' do
     klass = Foo.new
-    err = assert_raises(RuntimeError) { klass.xlsx_output_values }
-    assert_includes err.message, 'xlsx_output_values has to be defined in'
+    err = assert_raises(RuntimeError) { klass.xlsx_output_row_values }
+    assert_includes err.message, 'xlsx_output_row_values has to be defined in'
   end
 
   it 'needs xlsx_output_column_headers to be defined' do
@@ -31,7 +31,7 @@ describe WorkerTools::XlsxOutput do
         %w[foo1 goo2]
       end
 
-      def xlsx_output_values
+      def xlsx_output_row_values
         [
           %w[test1 testA],
           %w[test2 testB]
@@ -56,7 +56,7 @@ describe WorkerTools::XlsxOutput do
 
     it 'no method definition raises and methods are well defined' do
       assert @klass.xlsx_output_target
-      assert @klass.xlsx_output_values
+      assert @klass.xlsx_output_row_values
       assert @klass.xlsx_output_column_headers
     end
 
@@ -85,7 +85,7 @@ describe WorkerTools::XlsxOutput do
         { a: 'foo1', b: 'goo2' }
       end
 
-      def xlsx_output_values
+      def xlsx_output_row_values
         [
           { a: 'test1', b: 'testA' },
           { b: 'testB', a: 'test2' }
@@ -110,7 +110,7 @@ describe WorkerTools::XlsxOutput do
 
     it 'no method definition raises and methods are well defined' do
       assert @klass.xlsx_output_target
-      assert @klass.xlsx_output_values
+      assert @klass.xlsx_output_row_values
       assert @klass.xlsx_output_column_headers
     end
 
@@ -143,13 +143,13 @@ describe WorkerTools::XlsxOutput do
           sheet_1: {
             label: 'Test 1',
             headers: xlsx_output_column_headers,
-            rows: xlsx_output_values,
+            rows: xlsx_output_row_values,
             column_style: xlsx_output_column_format
           },
           sheet_2: {
             label: 'Test 2',
             headers: xlsx_output_column_headers,
-            rows: xlsx_output_values,
+            rows: xlsx_output_row_values,
             column_style: xlsx_output_column_format
           }
         }
@@ -159,7 +159,7 @@ describe WorkerTools::XlsxOutput do
         %w[foo1 goo2]
       end
 
-      def xlsx_output_values
+      def xlsx_output_row_values
         [
           %w[test1 testA],
           %w[test2 testB]
@@ -206,7 +206,7 @@ describe WorkerTools::XlsxOutput do
         { a: 'foo1', b: 'goo2' }
       end
 
-      def xlsx_output_values
+      def xlsx_output_row_values
         [
           { a: 'test1', b: 'testA' },
           { b: 'testB', a: 'test2' }
@@ -229,13 +229,13 @@ describe WorkerTools::XlsxOutput do
           sheet_1: {
             label: 'Test 1',
             headers: xlsx_output_column_headers,
-            rows: xlsx_output_values,
+            rows: xlsx_output_row_values,
             column_style: xlsx_output_column_format
           },
           sheet_2: {
             label: 'Test 2',
             headers: xlsx_output_column_headers,
-            rows: xlsx_output_values,
+            rows: xlsx_output_row_values,
             column_style: xlsx_output_column_format
           }
         }

--- a/test/worker_tools/xlsx_output_test.rb
+++ b/test/worker_tools/xlsx_output_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 describe WorkerTools::XlsxOutput do
-  class Foo
+  class FooXlsxOutput
     include WorkerTools::Basics
     include WorkerTools::XlsxOutput
 
@@ -21,19 +21,19 @@ describe WorkerTools::XlsxOutput do
   end
 
   it 'needs xlsx_output_row_values to be defined' do
-    klass = Foo.new
+    klass = FooXlsxOutput.new
     err = assert_raises(RuntimeError) { klass.xlsx_output_row_values }
     assert_includes err.message, 'xlsx_output_row_values has to be defined in'
   end
 
   it 'needs xlsx_output_column_headers to be defined' do
-    klass = Foo.new
+    klass = FooXlsxOutput.new
     err = assert_raises(RuntimeError) { klass.xlsx_output_column_headers }
     assert_includes err.message, 'xlsx_output_column_headers has to be defined in'
   end
 
   describe 'xlsx file output with array' do
-    class FooCorrectArray < Foo
+    class FooCorrectArray < FooXlsxOutput
       def xlsx_output_column_headers
         %w[foo1 goo2]
       end
@@ -81,8 +81,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with hash' do
-    class FooCorrectHash < Foo
-
+    class FooCorrectHash < FooXlsxOutput
       def xlsx_output_column_headers
         { a: 'foo1', b: 'goo2' }
       end
@@ -129,7 +128,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with array - multi sheet' do
-    class FooCorrectArrayMultiSheet < Foo
+    class FooCorrectArrayMultiSheet < FooXlsxOutput
       def xlsx_output_content
         {
           sheet_1: {
@@ -195,7 +194,7 @@ describe WorkerTools::XlsxOutput do
   end
 
   describe 'xlsx file output with hash - multi sheet' do
-    class FooCorrectHashMultiSheet < Foo
+    class FooCorrectHashMultiSheet < FooXlsxOutput
       def xlsx_output_column_headers
         { a: 'foo1', b: 'goo2' }
       end

--- a/test/worker_tools/xlsx_output_test.rb
+++ b/test/worker_tools/xlsx_output_test.rb
@@ -20,10 +20,10 @@ describe WorkerTools::XlsxOutput do
     end
   end
 
-  it 'needs xlsx_output_row_values to be defined' do
+  it 'needs xlsx_output_entries to be defined' do
     klass = FooXlsxOutput.new
-    err = assert_raises(RuntimeError) { klass.xlsx_output_row_values }
-    assert_includes err.message, 'xlsx_output_row_values has to be defined in'
+    err = assert_raises(RuntimeError) { klass.xlsx_output_entries }
+    assert_includes err.message, 'xlsx_output_entries has to be defined in'
   end
 
   it 'needs xlsx_output_column_headers to be defined' do
@@ -32,61 +32,13 @@ describe WorkerTools::XlsxOutput do
     assert_includes err.message, 'xlsx_output_column_headers has to be defined in'
   end
 
-  describe 'xlsx file output with array' do
-    class FooCorrectArray < FooXlsxOutput
-      def xlsx_output_column_headers
-        %w[foo1 goo2]
-      end
-
-      def xlsx_output_row_values
-        [
-          %w[test1 testA],
-          %w[test2 testB]
-        ]
-      end
-
-      def xlsx_output_column_format
-        {
-          a: { width: 20.0, text_wrap: true },
-          b: { width: 10.0 }
-        }
-      end
-    end
-
-    def setup
-      @klass = FooCorrectArray.new
-    end
-
-    it 'no method definition raises and methods are well defined' do
-      assert @klass.xlsx_output_row_values
-      assert @klass.xlsx_output_column_headers
-    end
-
-    it 'successful writing of xlsx file' do
-      assert @klass.xlsx_output_column_format
-      @klass.expects(:xlsx_output_style_columns).returns(true)
-
-      @klass.xlsx_output_write_file
-      attachment = @klass.model.attachments.first
-      assert attachment
-      xlsx = Roo::Excelx.new(attachment.file.path)
-
-      sheet = xlsx.sheet(0)
-      assert sheet
-      assert_equal xlsx.sheets, ['Sheet 1']
-      assert_equal sheet.row(1), %w[foo1 goo2]
-      assert_equal sheet.row(2), %w[test1 testA]
-      assert_equal sheet.row(3), %w[test2 testB]
-    end
-  end
-
   describe 'xlsx file output with hash' do
     class FooCorrectHash < FooXlsxOutput
       def xlsx_output_column_headers
         { a: 'foo1', b: 'goo2' }
       end
 
-      def xlsx_output_row_values
+      def xlsx_output_entries
         [
           { a: 'test1', b: 'testA' },
           { b: 'testB', a: 'test2' }
@@ -106,7 +58,7 @@ describe WorkerTools::XlsxOutput do
     end
 
     it 'no method definition raises and methods are well defined' do
-      assert @klass.xlsx_output_row_values
+      assert @klass.xlsx_output_row_values(@klass.xlsx_output_entries.first)
       assert @klass.xlsx_output_column_headers
     end
 


### PR DESCRIPTION
in practice we use model attachments all over the place

BREAKING CHANGES:

* Instead of writing the final csv or xlsx to a folder, the gem assumes that the model provides an `add_attachment` method
* Both csv & xlsx output modules use entry hashes for content (`csv_output_entries`, `xlsx_output_entries`).  The mapper methods   `csv_output_row_values` and  `xlsx_output_row_values`  do not need (in most cases)  to be defined, there is a default now.

Following methods do not exist anymore
  - `csv_output_target`
  - `cvs_output_target_folder`
  - `csv_output_target_file_name`
  - `csv_ouput_ensure_target_folder`
  - `csv_output_write_target`
  - `xlsx_output_target`
  - `xlsx_output_target_folder`
  - `xlsx_ensure_output_target_folder`
  - `xlsx_write_output_target`


These methods have been renamed for consistency 
  - `xlsx_output_values` => `xlsx_output_row_values`
  - `xlsx_insert_headers` => `xlsx_output_insert_headers`
  - `xlsx_insert_rows` => ` xlsx_output_insert_rows`
  - `xlsx_iterators` => `xlsx_output_iterators`
  - `xlsx_style_columns` => `xlsx_output_style_columns`
  - `xlsx_write_sheet` => `xlsx_output_write_sheet`


