### PR TITLE
adds xlsx_output_number_format

### DIFF
--- a/worker_tools.gemspec
+++ b/worker_tools.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop', '0.71.0'
+  spec.add_development_dependency 'rubocop', '0.72.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
```ruby
    def xlsx_output_number_format
      # set the cell number format for a given column
      # number format also applies to dates, see the excel documentation:
      #  https://support.microsoft.com/en-us/office/number-format-codes-in-excel-for-mac-5026bbd6-04bc-48cd-bf33-80f18b4eae68
      #  https://www.rubydoc.info/gems/rubyXL/3.3.21/RubyXL/NumberFormats
      #
      # Ex:
      # @xlsx_output_number_format ||= {
      #   foo: :auto,
      #   bar: '0.00',
      #   # nothing for baz, it will go through `.to_s`
      # }
      {}
    end
 ```